### PR TITLE
Fix constructor for PHP 7

### DIFF
--- a/google_analytics.php
+++ b/google_analytics.php
@@ -42,7 +42,7 @@ function printGoogleAnalyticsHeader() {
  */
 class google_analyticsOptions {
 
-	function google_analyticsOptions() {
+	function __construct() {
 		setOptionDefault('analyticsId', 'UA-xxxxxx-x');
 		setOptionDefault('admintracking', 0);
 	}


### PR DESCRIPTION
Getting a "Methods with the same name as their class will not be constructors in a future version of PHP" warning on PHP 7. Fix this.